### PR TITLE
break: update mariadb dependency and add support for enabled flag 🚀

### DIFF
--- a/charts/timelimit/Chart.lock
+++ b/charts/timelimit/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: mariadb
-  repository: https://charts.bitnami.com/bitnami
-  version: 22.0.0
-digest: sha256:c8f0269097d1731597ba842f8a90ecbc26561927ef9f7790e9deeb9ba28c7b36
-generated: "2025-08-18T19:00:25.856669432Z"
+  repository: oci://registry-1.docker.io/cloudpirates
+  version: 0.6.0
+digest: sha256:d9a845a7be249bad51eeb598cab24186fcda978c807b7c960708a2e9aacb3f7c
+generated: "2025-11-30T18:44:24.794652+01:00"

--- a/charts/timelimit/Chart.yaml
+++ b/charts/timelimit/Chart.yaml
@@ -17,7 +17,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 3.1.0
+version: 4.0.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
@@ -27,6 +27,6 @@ appVersion: "1.17.1"
 
 dependencies:
   - name: mariadb
-    version: 22.0.0
-    repository: https://charts.bitnami.com/bitnami
+    version: 0.6.0
+    repository: oci://registry-1.docker.io/cloudpirates
     condition: mariadb.enabled

--- a/charts/timelimit/tests/__snapshot__/simple_test.yaml.snap
+++ b/charts/timelimit/tests/__snapshot__/simple_test.yaml.snap
@@ -134,3 +134,71 @@ Supports DB_DRIVER:
               securityContext: {}
           securityContext: {}
           serviceAccountName: RELEASE-NAME-timelimit
+Supports mariadb.enabled true:
+  1: |
+    apiVersion: apps/v1
+    kind: Deployment
+    metadata:
+      labels:
+        app.kubernetes.io/instance: RELEASE-NAME
+        app.kubernetes.io/managed-by: Helm
+        app.kubernetes.io/name: timelimit
+        app.kubernetes.io/version: 1.17.1
+        helm.sh/chart: timelimit-0.2.8
+      name: RELEASE-NAME-timelimit
+    spec:
+      replicas: 1
+      selector:
+        matchLabels:
+          app.kubernetes.io/instance: RELEASE-NAME
+          app.kubernetes.io/name: timelimit
+      template:
+        metadata:
+          labels:
+            app.kubernetes.io/instance: RELEASE-NAME
+            app.kubernetes.io/name: timelimit
+        spec:
+          containers:
+            - env:
+                - name: NODE_ENV
+                  value: production
+                - name: DB_DRIVER
+                  value: mariadb
+                - name: DB_NAME
+                  value: RELEASE-NAME-timelimit
+                - name: DB_USER
+                  value: RELEASE-NAME-timelimit
+                - name: DB_PORT
+                  value: "3306"
+                - name: DB_HOST
+                  value: RELEASE-NAME-timelimit-mariadb
+                - name: DB_PASS
+                  value: ""
+                - name: PORT
+                  value: "8080"
+                - name: ALWAYS_PRO
+                  value: "no"
+                - name: ADMIN_TOKEN
+                  valueFrom:
+                    secretKeyRef:
+                      key: the-key
+                      name: the-secret-name
+              image: ghcr.io/michaelsp/timelimit-server/timelimit:latest
+              imagePullPolicy: IfNotPresent
+              livenessProbe:
+                httpGet:
+                  path: /time
+                  port: 8080
+              name: timelimit
+              ports:
+                - containerPort: 8080
+                  name: http
+                  protocol: TCP
+              readinessProbe:
+                httpGet:
+                  path: /time
+                  port: 8080
+              resources: {}
+              securityContext: {}
+          securityContext: {}
+          serviceAccountName: RELEASE-NAME-timelimit

--- a/charts/timelimit/tests/simple_test.yaml
+++ b/charts/timelimit/tests/simple_test.yaml
@@ -14,3 +14,9 @@ tests:
         enabled: true
     asserts:
       - matchSnapshot: {}
+  - it: Supports mariadb.enabled true
+    set:
+      mariadb:
+        enabled: true
+    asserts:
+      - matchSnapshot: {}


### PR DESCRIPTION
Updated the mariadb dependency to version 0.6.0 and changed the repository to use the OCI registry. Added a test case to ensure support for the mariadb.enabled flag in the Helm chart.

<!--
To streamline the process of creating and reviewing pull requests, we have created a template.
It is not required to follow this template perfectly, but we encourage you to think about each header.
Before you publish a pull request think about the definition of done for the issue you are trying to resolve.
-->

<!--
Provide the key for the Jira issue this PR resolves.
-->

BREAKING CHANGE: switch from bitnami to cloud-pirates mariaDB due to bitnami version change

## Description
<!--
Provide a concise description on the feature/fix your pull request implements.
-->

## Changes
<!--
Provide a list of important changes.

e.g.
* Added tests
* Renamed variable
* Added topic
-->

## Testing

<!-- Provide additional information necessary for testing this PR. This includes details like branches in other repos, launch arguments or gait directories. In the case of a bug fix, provide the steps to reproduce the bug.-->

<!-- Reviews are automatically requested after the pull request has been created. Only request for a review if you want a specific person to review your changes.-->
